### PR TITLE
feat: Node environment-dependent etag generation changed to etag generation using WebAPI Crypto

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,13 +8,9 @@
       "name": "remix-etag",
       "version": "0.2.1",
       "license": "MIT",
-      "dependencies": {
-        "etag": "^1.8.1"
-      },
       "devDependencies": {
         "@remix-run/node": "^1.3.2",
         "@size-limit/preset-small-lib": "^7.0.8",
-        "@types/etag": "^1.8.1",
         "husky": "^7.0.4",
         "size-limit": "^7.0.8",
         "tsdx": "^0.14.1",
@@ -2568,15 +2564,6 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
       "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
       "dev": true
-    },
-    "node_modules/@types/etag": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@types/etag/-/etag-1.8.1.tgz",
-      "integrity": "sha512-bsKkeSqN7HYyYntFRAmzcwx/dKW4Wa+KVMTInANlI72PWLQmOpZu96j0OqHZGArW4VQwCmJPteQlXaUDeOB0WQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.5",
@@ -5828,14 +5815,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/etag": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/event-target-shim": {
@@ -14895,15 +14874,6 @@
       "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
       "dev": true
     },
-    "@types/etag": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@types/etag/-/etag-1.8.1.tgz",
-      "integrity": "sha512-bsKkeSqN7HYyYntFRAmzcwx/dKW4Wa+KVMTInANlI72PWLQmOpZu96j0OqHZGArW4VQwCmJPteQlXaUDeOB0WQ==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/graceful-fs": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -17324,11 +17294,6 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
-    },
-    "etag": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
     "event-target-shim": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -47,15 +47,11 @@
   "devDependencies": {
     "@remix-run/node": "^1.3.2",
     "@size-limit/preset-small-lib": "^7.0.8",
-    "@types/etag": "^1.8.1",
     "husky": "^7.0.4",
     "size-limit": "^7.0.8",
     "tsdx": "^0.14.1",
     "tslib": "^2.3.1",
     "typescript": "^4.6.2"
-  },
-  "dependencies": {
-    "etag": "^1.8.1"
   },
   "jest": {
     "coverageThreshold": {

--- a/src/eTag.ts
+++ b/src/eTag.ts
@@ -6,11 +6,7 @@ const entityTag = async (entity: string): Promise<string> => {
   const target = new TextEncoder().encode(entity);
   const hashBuffer = await crypto.subtle.digest('SHA-1', target);
   const hashArray = Array.from(new Uint8Array(hashBuffer));
-  const hashHex = hashArray
-    .map(function(b) {
-      return b.toString(16).padStart(2, '0');
-    })
-    .join('');
+  const hashHex = hashArray.map(n => n.toString(16).padStart(2, '0')).join('');
 
   return `"${hashHex}"`;
 };

--- a/src/eTag.ts
+++ b/src/eTag.ts
@@ -1,30 +1,28 @@
-async function entityTag(entity: string): Promise<string> {
+const entityTag = async (entity: string): Promise<string> => {
   if (entity.length === 0) {
-    // fast-path empty
-    return '"0-2jmj7l5rSw0yVb/vlWAYkK/YBwk"';
+    return '"0a4d55a8d778e5022fab701977c5d840bbc486d0"';
   }
-  const target = new TextEncoder().encode(entity);
-  const hash = await crypto.subtle.digest('SHA-1', target).then(hashBuffer => {
-    const hashArray = Array.from(new Uint8Array(hashBuffer));
-    const hashHex = hashArray
-      .map(function(b) {
-        return b.toString(16).padStart(2, '0');
-      })
-      .join('');
-    return hashHex;
-  });
 
-  return `"${hash}"`;
-}
+  const target = new TextEncoder().encode(entity);
+  const hashBuffer = await crypto.subtle.digest('SHA-1', target);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  const hashHex = hashArray
+    .map(function(b) {
+      return b.toString(16).padStart(2, '0');
+    })
+    .join('');
+
+  return `"${hashHex}"`;
+};
 
 /**
  * Create a simple ETag.
  */
 
-export async function createEtag(
+export const createEtag = async (
   entity: string,
   options?: { weak: boolean }
-): Promise<string> {
+): Promise<string> => {
   if (entity == null) {
     throw new TypeError('argument entity is required');
   }
@@ -33,4 +31,4 @@ export async function createEtag(
   const tag = await entityTag(entity);
 
   return options?.weak ? `W/${tag}` : tag;
-}
+};

--- a/src/eTag.ts
+++ b/src/eTag.ts
@@ -1,0 +1,36 @@
+async function entityTag(entity: string): Promise<string> {
+  if (entity.length === 0) {
+    // fast-path empty
+    return '"0-2jmj7l5rSw0yVb/vlWAYkK/YBwk"';
+  }
+  const target = new TextEncoder().encode(entity);
+  const hash = await crypto.subtle.digest('SHA-1', target).then(hashBuffer => {
+    const hashArray = Array.from(new Uint8Array(hashBuffer));
+    const hashHex = hashArray
+      .map(function(b) {
+        return b.toString(16).padStart(2, '0');
+      })
+      .join('');
+    return hashHex;
+  });
+
+  return `"${hash}"`;
+}
+
+/**
+ * Create a simple ETag.
+ */
+
+export async function createEtag(
+  entity: string,
+  options?: { weak: boolean }
+): Promise<string> {
+  if (entity == null) {
+    throw new TypeError('argument entity is required');
+  }
+
+  // generate entity tag
+  const tag = await entityTag(entity);
+
+  return options?.weak ? `W/${tag}` : tag;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,6 @@ export const etag = async ({
   const clonedResponse = response.clone();
   const body = await clonedResponse.text();
 
-  const isMatch = testMatch({ request, text: body, headers, weak });
+  const isMatch = await testMatch({ request, text: body, headers, weak });
   return isMatch ? new Response('', { status: 304, headers }) : response;
 };

--- a/src/testMatch.ts
+++ b/src/testMatch.ts
@@ -1,4 +1,4 @@
-import computeETag from 'etag';
+import { createEtag } from './eTag';
 
 const stripLeadingWeak = (hash: string) => hash.replace(/^W\//, '');
 
@@ -30,13 +30,13 @@ type TestMatch = {
  * The raw `testMatch` function that could be used to compare the RemixContext.routeData and
  * return early without rendering the page if `true` is returned.
  */
-export const testMatch = ({
+export const testMatch = async ({
   request,
   text,
   headers,
   weak,
-}: TestMatch): boolean => {
-  const etagHash = computeETag(text, { weak });
+}: TestMatch): Promise<boolean> => {
+  const etagHash = await createEtag(text, { weak });
   headers.set('ETag', etagHash);
 
   const ifNoneMatch = request.headers.get('if-none-match');


### PR DESCRIPTION
Hello.

Thank you for the very useful article and library.

I am using Remix in a Cloudflare Workers and was not able to use `remix-etag` in a Cloudflare Workers environment because the `etag` package that `remix-etag` uses depends on `crypto`.(`Crypto` doesn't work with Cloudflare Workers.)

https://developer.mozilla.org/en-US/docs/Web/API/Crypto
https://community.cloudflare.com/t/set-etag-in-worker/178881

So, I changed the crypto part used by etag to use WebAPI Crypto, which I think is better suited for Remix users. For example, how about this implementation?